### PR TITLE
fix: code health improvements (8 items)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,7 +30,12 @@ fn main() -> Result<()> {
         }
 
         let duration = start.elapsed();
-        println!("Processed {} files {}x in {:?}", files.len(), COUNT, duration);
+        println!(
+            "Processed {} files {}x in {:?}",
+            files.len(),
+            COUNT,
+            duration
+        );
     } else {
         process_files(&files, true)?;
     }
@@ -39,11 +44,8 @@ fn main() -> Result<()> {
 }
 fn process_files(files: &[PathBuf], print: bool) -> Result<()> {
     for file in files {
-        let hash = oshash(
-            file.to_str()
-                .context("could not convert path to UTF-8")?,
-        )
-        .with_context(|| format!("Failed to hash file: {}", file.display()))?;
+        let hash = oshash(file.to_str().context("could not convert path to UTF-8")?)
+            .with_context(|| format!("Failed to hash file: {}", file.display()))?;
 
         if print {
             println!("{hash} {}", file.display());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
         }
 
         let duration = start.elapsed();
-        println!("Processed {} files 1000x in {:?}", files.len(), duration);
+        println!("Processed {} files {}x in {:?}", files.len(), COUNT, duration);
     } else {
         process_files(&files, true)?;
     }
@@ -40,9 +40,8 @@ fn main() -> Result<()> {
 fn process_files(files: &[PathBuf], print: bool) -> Result<()> {
     for file in files {
         let hash = oshash(
-            file.as_os_str()
-                .to_str()
-                .context("could not convert to os_str")?,
+            file.to_str()
+                .context("could not convert path to UTF-8")?,
         )
         .with_context(|| format!("Failed to hash file: {}", file.display()))?;
 

--- a/examples/simple_hash.rs
+++ b/examples/simple_hash.rs
@@ -1,18 +1,20 @@
 use std::env;
 
-#[cfg(not(feature = "tokio"))]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use oshash::oshash;
+fn parse_args() -> String {
     let args: Vec<String> = env::args().collect();
-
     if args.len() != 2 {
         eprintln!("Usage: {} <file_path>", args[0]);
         std::process::exit(1);
     }
+    args[1].clone()
+}
 
-    let file_path = &args[1];
+#[cfg(not(feature = "tokio"))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use oshash::oshash;
+    let file_path = parse_args();
 
-    match oshash(file_path) {
+    match oshash(&file_path) {
         Ok(hash) => {
             println!("OSHash of '{}': {}", file_path, hash);
         }
@@ -29,16 +31,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use oshash::oshash_async;
-    let args: Vec<String> = env::args().collect();
+    let file_path = parse_args();
 
-    if args.len() != 2 {
-        eprintln!("Usage: {} <file_path>", args[0]);
-        std::process::exit(1);
-    }
-
-    let file_path = &args[1];
-
-    match oshash_async(file_path).await {
+    match oshash_async(&file_path).await {
         Ok(hash) => {
             println!("OSHash of '{}': {}", file_path, hash);
         }

--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -70,33 +70,26 @@ where
     }
 
     let current_offset = file.stream_position().await?;
+    let result = oshash_buf_async_inner(file, len).await;
+    // Always restore the original seek position, even on error
+    let _ = file.seek(io::SeekFrom::Start(current_offset)).await;
+    result
+}
 
+async fn oshash_buf_async_inner<T>(file: &mut T, len: u64) -> Result<String, HashError>
+where
+    T: AsyncSeekExt + AsyncReadExt + Unpin,
+{
     let mut file_hash: u64 = len;
-
     let mut buffer = vec![0u8; CHUNK_SIZE];
 
-    // Read first CHUNK_SIZE bytes
     file.seek(io::SeekFrom::Start(0)).await?;
     file.read_exact(&mut buffer).await?;
+    accumulate(&mut file_hash, &buffer);
 
-    for chunk in buffer.chunks_exact(8) {
-        file_hash = file_hash.wrapping_add(u64::from_le_bytes(
-            chunk.try_into().expect("chunk size is 8"),
-        ));
-    }
-
-    // Read last CHUNK_SIZE bytes
     file.seek(io::SeekFrom::End(-(CHUNK_SIZE as i64))).await?;
     file.read_exact(&mut buffer).await?;
-
-    for chunk in buffer.chunks_exact(8) {
-        file_hash = file_hash.wrapping_add(u64::from_le_bytes(
-            chunk.try_into().expect("chunk size is 8"),
-        ));
-    }
-
-    // Restore original position
-    file.seek(io::SeekFrom::Start(current_offset)).await?;
+    accumulate(&mut file_hash, &buffer);
 
     Ok(format!("{file_hash:016x}"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,13 @@ mod sync;
 const CHUNK_SIZE: usize = 65536;
 const MIN_FILE_SIZE: usize = 2 * CHUNK_SIZE;
 
+const _: () = assert!(
+    CHUNK_SIZE % 8 == 0,
+    "CHUNK_SIZE must be divisible by 8 for u64 chunk parsing"
+);
+
 /// Accumulates little-endian u64 chunks from `buffer` into `file_hash` via wrapping addition.
 fn accumulate(file_hash: &mut u64, buffer: &[u8]) {
-    debug_assert!(
-        CHUNK_SIZE % 8 == 0,
-        "CHUNK_SIZE must be divisible by 8 for u64 chunk parsing"
-    );
     for chunk in buffer.chunks_exact(8) {
         *file_hash = file_hash.wrapping_add(u64::from_le_bytes(
             chunk.try_into().expect("chunk size is 8"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,16 @@ mod sync;
 const CHUNK_SIZE: usize = 65536;
 const MIN_FILE_SIZE: usize = 2 * CHUNK_SIZE;
 
+/// Accumulates little-endian u64 chunks from `buffer` into `file_hash` via wrapping addition.
+fn accumulate(file_hash: &mut u64, buffer: &[u8]) {
+    debug_assert!(CHUNK_SIZE % 8 == 0, "CHUNK_SIZE must be divisible by 8 for u64 chunk parsing");
+    for chunk in buffer.chunks_exact(8) {
+        *file_hash = file_hash.wrapping_add(u64::from_le_bytes(
+            chunk.try_into().expect("chunk size is 8"),
+        ));
+    }
+}
+
 /// Error type returned by oshash functions.
 #[derive(Debug)]
 #[non_exhaustive]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,10 @@ const MIN_FILE_SIZE: usize = 2 * CHUNK_SIZE;
 
 /// Accumulates little-endian u64 chunks from `buffer` into `file_hash` via wrapping addition.
 fn accumulate(file_hash: &mut u64, buffer: &[u8]) {
-    debug_assert!(CHUNK_SIZE % 8 == 0, "CHUNK_SIZE must be divisible by 8 for u64 chunk parsing");
+    debug_assert!(
+        CHUNK_SIZE % 8 == 0,
+        "CHUNK_SIZE must be divisible by 8 for u64 chunk parsing"
+    );
     for chunk in buffer.chunks_exact(8) {
         *file_hash = file_hash.wrapping_add(u64::from_le_bytes(
             chunk.try_into().expect("chunk size is 8"),

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -67,33 +67,26 @@ where
     }
 
     let current_offset = file.stream_position()?;
+    let result = oshash_buf_inner(file, len);
+    // Always restore the original seek position, even on error
+    let _ = file.seek(io::SeekFrom::Start(current_offset));
+    result
+}
 
+fn oshash_buf_inner<T>(file: &mut T, len: u64) -> Result<String, HashError>
+where
+    T: Seek + Read,
+{
     let mut file_hash: u64 = len;
-
     let mut buffer = vec![0u8; CHUNK_SIZE];
 
-    // Read first CHUNK_SIZE bytes
     file.seek(io::SeekFrom::Start(0))?;
     file.read_exact(&mut buffer)?;
+    accumulate(&mut file_hash, &buffer);
 
-    for chunk in buffer.chunks_exact(8) {
-        file_hash = file_hash.wrapping_add(u64::from_le_bytes(
-            chunk.try_into().expect("chunk size is 8"),
-        ));
-    }
-
-    // Read last CHUNK_SIZE bytes
     file.seek(io::SeekFrom::End(-(CHUNK_SIZE as i64)))?;
     file.read_exact(&mut buffer)?;
-
-    for chunk in buffer.chunks_exact(8) {
-        file_hash = file_hash.wrapping_add(u64::from_le_bytes(
-            chunk.try_into().expect("chunk size is 8"),
-        ));
-    }
-
-    // Restore original position
-    file.seek(io::SeekFrom::Start(current_offset))?;
+    accumulate(&mut file_hash, &buffer);
 
     Ok(format!("{file_hash:016x}"))
 }

--- a/tests/async_integration_tests.rs
+++ b/tests/async_integration_tests.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "tokio")]
 use std::io;
-#[cfg(feature = "tokio")]
-use std::path::Path;
 
 #[cfg(feature = "tokio")]
 use oshash::{oshash_async, oshash_buf_async, HashError};
@@ -13,26 +11,17 @@ use tokio::io::AsyncSeekExt;
 #[cfg(feature = "tokio")]
 #[tokio::test]
 async fn it_hashes_properly_async() {
-    let path = Path::new("test-resources/testdata")
-        .as_os_str()
-        .to_str()
-        .unwrap();
-    let result = oshash_async(path).await.unwrap();
+    let result = oshash_async("test-resources/testdata").await.unwrap();
     assert_eq!(result, "40d354daf3acce9c");
 }
 
 #[cfg(feature = "tokio")]
 #[tokio::test]
 async fn it_throws_io_error_async() {
-    let path = Path::new("test-resources/dne")
-        .as_os_str()
-        .to_str()
-        .unwrap();
-    let result = oshash_async(path).await;
+    let result = oshash_async("test-resources/dne").await;
     assert!(result.is_err());
     match result {
         Err(HashError::IoError(_)) => {
-            let _ = result.unwrap_err().to_string();
             // Expected error, test passes
         }
         _ => panic!("Unexpected error"),
@@ -42,11 +31,7 @@ async fn it_throws_io_error_async() {
 #[cfg(feature = "tokio")]
 #[tokio::test]
 async fn it_throw_error_when_input_too_small() {
-    let path = Path::new("test-resources/too_small")
-        .as_os_str()
-        .to_str()
-        .unwrap();
-    let result = oshash_async(path).await;
+    let result = oshash_async("test-resources/too_small").await;
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "File size too small");
 }
@@ -54,11 +39,7 @@ async fn it_throw_error_when_input_too_small() {
 #[cfg(feature = "tokio")]
 #[tokio::test]
 async fn it_throws_error_if_file_does_not_exist() {
-    let path = Path::new("test-resources/does_not_exist")
-        .as_os_str()
-        .to_str()
-        .unwrap();
-    let result = oshash_async(path).await;
+    let result = oshash_async("test-resources/does_not_exist").await;
     assert!(result.is_err());
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,30 +1,20 @@
 use std::fs::File;
 use std::io::{self, Seek};
-use std::path::Path;
 
 use oshash::{oshash, oshash_buf, HashError};
 
 #[test]
 fn it_hashes_properly() {
-    let path = Path::new("test-resources/testdata")
-        .as_os_str()
-        .to_str()
-        .unwrap();
-    let result = oshash(path).unwrap();
+    let result = oshash("test-resources/testdata").unwrap();
     assert_eq!(result, "40d354daf3acce9c");
 }
 
 #[test]
 fn it_throws_io_error() {
-    let path = Path::new("test-resources/dne")
-        .as_os_str()
-        .to_str()
-        .unwrap();
-    let result = oshash(path);
+    let result = oshash("test-resources/dne");
     assert!(result.is_err());
     match result {
         Err(HashError::IoError(_)) => {
-            let _ = result.unwrap_err().to_string();
             // Expected error, test passes
         }
         _ => panic!("Unexpected error"),
@@ -33,22 +23,14 @@ fn it_throws_io_error() {
 
 #[test]
 fn it_throw_error_when_input_too_small() {
-    let path = Path::new("test-resources/too_small")
-        .as_os_str()
-        .to_str()
-        .unwrap();
-    let result = oshash(path);
+    let result = oshash("test-resources/too_small");
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "File size too small");
 }
 
 #[test]
 fn it_throws_error_if_file_does_not_exist() {
-    let path = Path::new("test-resources/does_not_exist")
-        .as_os_str()
-        .to_str()
-        .unwrap();
-    let result = oshash(path);
+    let result = oshash("test-resources/does_not_exist");
     assert!(result.is_err());
 }
 


### PR DESCRIPTION
- fix seek position not restored on error paths in sync/async oshash_buf
- extract accumulate() helper to eliminate duplicated hash loop
- add debug_assert for CHUNK_SIZE divisibility invariant
- remove unnecessary Path conversions in tests (oshash accepts &str)
- remove dead to_string() calls in test error assertions
- fix hardcoded "1000x" in CLI benchmark output to use COUNT
- simplify path.to_str() conversion in CLI loop
- extract parse_args() helper in example to remove duplication

## Description

<!-- What does this PR do? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code health
- [ ] CI / tooling

## Checklist

- [ ] `cargo test --all-features` passes
- [ ] `cargo clippy --all-features` passes with no new warnings
- [ ] Public API changes are documented
- [ ] MSRV (1.60) is respected — no features from newer Rust versions used
- [ ] Semver impact considered (breaking changes bump the major version)
